### PR TITLE
Fix broken table in `Avoid Mutable Globals` section

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -1024,6 +1024,7 @@ func (s *signer) Sign(msg string) string {
 ```
 </td></tr>
 <tr><td>
+
 ```go
 // sign_test.go
 


### PR DESCRIPTION
## Before

<img width="833" alt="Screen Shot 2020-07-08 at 23 12 28" src="https://user-images.githubusercontent.com/1532891/86929221-8fb93900-c170-11ea-9a30-ce9787896e47.png">

## After

<img width="661" alt="Screen Shot 2020-07-08 at 23 12 41" src="https://user-images.githubusercontent.com/1532891/86929240-9778dd80-c170-11ea-96f8-f101120ed7c0.png">

---

Referenced from https://github.com/uber-go/guide/blob/master/style.md#avoid-mutable-globals
